### PR TITLE
Docs: Fix typos and grammar across multiple course pages

### DIFF
--- a/content/02-kotlin/_index.md
+++ b/content/02-kotlin/_index.md
@@ -505,7 +505,7 @@ printall("Lorem", "ipsum", "dolor", "sit", "amet")
 
 Kotlin is less permissive than Scala:
 * Arbitrary symbols are not accepted as valid function names
-* ...unless you explicitly surround them with backtics
+* ...unless you explicitly surround them with backticks
 
 ```scala
 def ##°@??%&@^^() = 1 // Super ok for Scala: def $hash$hash$u00B0$at$qmark$qmark$percent$amp$at$up$up(): Int
@@ -669,7 +669,7 @@ outerloop@ for (i in 1..100) {
 * Similar to Scala, the keyword `class` introduces a class definition
 * Object construction does not require `new`
     * `new` is not a Kotlin keyword at all
-* Objecs get built from classes by just invoking the class name:
+* Objects get built from classes by just invoking the class name:
 
 ```Kotlin
 class Foo
@@ -1182,7 +1182,7 @@ This will turn useful in future...
 | `x %= y` | `remAssign` | `x.remAssign(y)` |
 
 * Assignment functions *can be defined only if their arithmetic equivalent is undefined*.
-* If an aritmetic operator `op` is defined, the compiler infers the assign version as:
+* If an arithmetic operator `op` is defined, the compiler infers the assign version as:
     * `a op= b` $\Rightarrow$ `a = a op b`
 
 
@@ -1326,7 +1326,7 @@ fun <T, P, A, L, R, N, E> navigationStrategy()
 
 Kotlin supports (co/contro)variance using:
 * `<out T>` to mark covariance (similar to Java's `<? extends T>`)
-* `<in T>` to mark controvariance (similar to Java's `<? super T>`)
+* `<in T>` to mark contravariance (similar to Java's `<? super T>`)
 * `<*>` to mark that only the bound is known for the type (similar to Java's `<?>`)
 
 Type variant in Kotlin is expressed *at declaration site*!
@@ -1616,7 +1616,7 @@ some delegates are built-in, e.g. `lazy`
 ```kotlin
 val someLazyString by lazy {
     println("I'm initializing myself")
-    "I'm intialized"
+    "I'm initialized"
 }
 println("Doing stuff")
 println(someLazyString) // "I'm initializing myself" gets printed here
@@ -1969,7 +1969,7 @@ mutableListOf<String>().configure {
 
 ## Extension members and implicit receivers
 
-When extensions are defined as members, there are multiple *implicit recevers*:
+When extensions are defined as members, there are multiple *implicit receivers*:
 1. **dispatch receiver**: the `object` or instance of the `class` in which the extension is declared
 2. **extension receiver** the instance of the *receiver type* of the extension is called
 
@@ -2129,7 +2129,7 @@ A lot of language details have been left out of this guide, non complete list:
 * spread operator
 * annotations
 * coroutines
-* interoperatibility with Java, Javscript, and C
+* interoperability with Java, Javascript, and C
 * `value class`es
 * context parameters
 

--- a/content/03-internal-dsls/_index.md
+++ b/content/03-internal-dsls/_index.md
@@ -150,7 +150,7 @@ interface Element {
 }
 ```
 
-* `TextElement`s are composed of simple `text`, possibly rendered with intentation
+* `TextElement`s are composed of simple `text`, possibly rendered with indentation
 ```kotlin
 interface TextElement : RepeatableElement {
     val text: String

--- a/content/04-build-automation/_generator.md
+++ b/content/04-build-automation/_generator.md
@@ -105,10 +105,10 @@ file(COPY ${data} DESTINATION resources)
 
 ---
 
-Depedency management, imperative:
+Dependency management, imperative:
 
 ```cmake
-# This defines the variables Boost_LIBRARIES that containts all library names
+# This defines the variables Boost_LIBRARIES that contains all library names
 # that we need to link into the program.
 find_package(Boost 1.36.0 COMPONENTS filesystem system REQUIRED)
 
@@ -1088,7 +1088,7 @@ for gradle to mark it as an *input* or an *output*.
 #### Why?
 
 1. **Performance**
-    * Gradle caches intermediate build results, using input and output markers to undersand whether or not some task is *up to date*
+    * Gradle caches intermediate build results, using input and output markers to understand whether or not some task is *up to date*
     * This allows for *much* faster builds while working on large projects
         * Time to build completion can decrease a dozen minutes to seconds!
 2. **Continuous build**
@@ -1694,7 +1694,7 @@ dependencies {
 ```
 
 Uhmm...
-* it's still repetitive (can be furter factorized by bundling the kotest modules)
+* it's still repetitive (can be further factorized by bundling the kotest modules)
 * the function and version could be included in `buildSrc`
 * custom solutions can be nice, but:
     1. they can be hard to understand, as they are not standard
@@ -1741,10 +1741,10 @@ We now have three different runtimes at play:
     * In case of native projects, the target OS / architecture
 2. One or more **runtime targets**
     * In case of JVM or .NET projects the virtual machines we want to support
-3. A **built-time runtime**
+3. A **build-time runtime**
     * In case of Gradle, the JVM running the build system
 
-These toolchains *should be controlled indipendently*!
+These toolchains *should be controlled independently*!
 
 You may want to use Java 17 to run Gradle, but compile in a Java 8-compatible bytecode, and then test on Java 11.
 
@@ -2095,7 +2095,7 @@ Software repositories are services hosting software artifacts for distribution
     * Not really enforced, but strongly recommended
 * *NPM* for Javascript
   * Supports package **retraction** within *72-hours *if* there are *no dependents*, or after only if:
-    * there are no dependents, fewer than 300 downloads last wee, and a single owner.
+    * there are no dependents, fewer than 300 downloads last week, and a single owner.
     * retracted versions are banned
 * *PyPI*: for Python code
   * Supports **yanking** (preferred), deletion is being discussed.

--- a/content/05-version-selection/_index.md
+++ b/content/05-version-selection/_index.md
@@ -124,7 +124,7 @@ The version is represented one or more sequences, separately incremented, that
 
 Combination of all the techniques:
 * *Dates* (Windows 9x, 2001)
-* *Codenames* (NT, Vista, XP, Millenium Edition)
+* *Codenames* (NT, Vista, XP, Millennium Edition)
 * Pre-release codenames (Longhorn)
 * Dates for internal builds
 * Incremental versions on *multiple levels*

--- a/content/07-ci/generator.md
+++ b/content/07-ci/generator.md
@@ -207,7 +207,7 @@ runs:
   using: "composite"
   steps:
     - run: '[[ -n "${{ inputs.token }}" ]] || false'
-      name: Fail if the toke is unset
+      name: Fail if the token is unset
 ```
 
 * ~~No conditional steps (ouch...)~~
@@ -341,7 +341,7 @@ $\Rightarrow$ *write __workflows__*, *use __jobs__*
 2. *Nobody touches it* for months
 3. Untouched stuff is now *borked*!
 
-Ever happenend?
+Ever happened?
 
 * Connected to the issue of **build reproducibility**
     * The higher the build *reproducibility*, the higher its *robustness*

--- a/content/08-advanced-git/_index.md
+++ b/content/08-advanced-git/_index.md
@@ -31,7 +31,7 @@ Git supports two types of tags:
     * simply a name for an object (usually a commit)
     * meant for creating **private** or **temporary** annotations!
 * **annotated** tags
-    * Produced with `-a` (unsigend), `-s`, or `-u` options
+    * Produced with `-a` (unsigned), `-s`, or `-u` options
     * Creates a *new object*
     * Contain *message*, *creation date*, *tagger name* and *email*, and an optional *signature*
     * Annotated tags are **meant for release**

--- a/content/09-containerization/_index.md
+++ b/content/09-containerization/_index.md
@@ -1048,7 +1048,7 @@ To exemplify the usage of IP:
 3. open your browser and browse to `http://172.17.0.2:8080`
     * you should see a page of the form: `[$SERVER_ID@$HOST_NAME:PORT] Hit $VIEW_COUNT times`
     * the page is served by the container, contacted by IP
-    * so containes attached to `bridge`-like networks can be contacted by IP, from the host
+    * so containers attached to `bridge`-like networks can be contacted by IP, from the host
 
 4. try to contact the container:
     * by host name, from the host
@@ -1881,7 +1881,7 @@ class TestMariaDBCustomerRepository {
 
 {{% /col %}}
 {{% col %}}
-- Unit thest for the `SqlCustomerRepository` class
+- Unit test for the `SqlCustomerRepository` class
 
 - Requires an instance of MariaDB to be tested
 
@@ -1930,7 +1930,7 @@ class TestMariaDBCustomerRepository {
 
 ## Building the cluster (practice)
 
-1. On one node running the Docker deamon (say, the teacher's machine), initialise Swarm mode as follows:
+1. On one node running the Docker daemon (say, the teacher's machine), initialise Swarm mode as follows:
     * `docker swarm init`
     * this will output a command to be run on other nodes to join the cluster:
         ```
@@ -2132,7 +2132,7 @@ Upon environment selection, one is presented with the _dashboard_, showing the _
 
 After selecting the only environment available, one may observe:
 - which and how many __nodes__ compose the cluster (_Dashboard_ section)
-    + you may use the _cluster visualiser_ to spot your machien in the cluster
+    + you may use the _cluster visualiser_ to spot your machine in the cluster
         * (assuming that you managed to join the cluster)
 
 - which __stacks__ are running on the cluster (_Services_ section)

--- a/content/12-multiplatform/_index.md
+++ b/content/12-multiplatform/_index.md
@@ -516,7 +516,7 @@ The __choice__ of a _platform_ impacts developers during:
 
 + The abstraction gap is likely lower
 
-+ More third party libraries are likey available
++ More third party libraries are likely available
 
 + The potential audience is wider
   * implies the SW project is more valuable
@@ -678,7 +678,7 @@ The __choice__ of a _platform_ impacts developers during:
 
 - Assumptions:
   * one "super-language" exists, having:
-    1. a code-generator targetting multiple platforms
+    1. a code-generator targeting multiple platforms
         + e.g. compiler, transpiler, etc.
     2. the same standard library implemented for all those platforms
 
@@ -946,7 +946,7 @@ Defines several aspects of the project:
 - which repositories should Gradle use when looking for dependencies
     ```kotlin
     repositories { 
-        mavenCentral() // use MCR for downloading dependencies (recommneded)
+        mavenCentral() // use MCR for downloading dependencies (recommended)
 
         // other custom repositories here (discouraged)
     } 
@@ -967,7 +967,7 @@ Defines several aspects of the project:
         }
         // declares JavaScript as target
         js {
-            useCommonJs() // use CommonJS for JS depenencies management
+            useCommonJs() // use CommonJS for JS dependencies management
             // or useEsModules() 
             binaries.executable() // enables tasks for Node packages generation
             // the target will consist of a Node project (with NodeJS's stdlib)
@@ -2337,7 +2337,7 @@ In the `jsMain` source set
     * via the various `*Jar` or `assemble` tasks
 
 - The `jsMain` source set is compiled into either
-    * a Kotlin library (`.klib`), enabling imporing the project tas dependency in Kotlin/JS projects
+    * a Kotlin library (`.klib`), enabling importing the project as dependency in Kotlin/JS projects
         + via the various `*Jar` or `assemble` tasks
     * a NodeJS project
         + via the `compileProductionExecutableKotlinJs` task
@@ -2383,7 +2383,7 @@ In the `jsMain` source set
 - Kotlin code can be called from the target platforms' main languages
     + e.g. Java, JavaScript, etc.
 
-- Understading the mapping among Kotlin and other languages is key
+- Understanding the mapping among Kotlin and other languages is key
     + it impacts the usability of Kotlin libraries for ordinary platform users
 
 > How are Kotlin's syntactical categories mapped to other platforms/languages?
@@ -3451,7 +3451,7 @@ For all __public types__ in the wrapped _Java library_:
     header1 = jcsv.header("column1", "column2", "column3") 
     header2 = jcsv.header(3) # anonymous header with 3 columns
     columns = (f"column{i}" for i in range(1, 4)) # generator expression
-    header3 = jcsv.header(columns) # same as header1, but passing an interable
+    header3 = jcsv.header(columns) # same as header1, but passing an iterable
     ```
 
 - Function `iterable_or_varargs` aims at _simulating_ **multiple overloads**:

--- a/content/extra/devops-dir/_index.md
+++ b/content/extra/devops-dir/_index.md
@@ -235,7 +235,7 @@ $\Rightarrow$
 ## *Continuous Integration / Deployment / Delivery*
 
 * Adding **CI** to existing projects
-  * Needs a *committment to* the *DevOps* philosophy
+  * Needs a *commitment to* the *DevOps* philosophy
 * *Multiplatform* testing
   * OS type and version
   * Platform (JDK, CLR, Python interpreter) version

--- a/content/extra/kubernetes/_index.md
+++ b/content/extra/kubernetes/_index.md
@@ -43,7 +43,7 @@ enableSourceMap = true
 
 # {{< course_name >}}
 
-## Intoduction to Kubernetes
+## Introduction to Kubernetes
 
 ### [Martina Baiardi - m.baiardi@unibo.it](mailto:m.baiardi@unibo.it)
 
@@ -244,7 +244,7 @@ And the list goes on...
   - there are external Metrics Servers which can be adopted instead of it. 
 - There are mainly three kinds of metrics: 
   - **Resource Metrics**: concerning *memory* and *cpu* of Kubernetes' resource objects.
-  - **Custom Metrics**: other information about Kubernetes' resource objecs.
+  - **Custom Metrics**: other information about Kubernetes' resource objects.
   - **External Metrics**: metrics not related with Kubernetes' resources (i.e. number of incoming HTTP requests)
 
 --- 
@@ -309,9 +309,9 @@ And the list goes on...
 
 ### Kubernetes smallest deployable unit.
 - Runs one (or more) containers
-  - Pods allow to deploy toghether two different containers that are symbiotic between themself
+  - Pods allow to deploy together two different containers that are symbiotic between themselves
     - for example, a web server container and the git synchronizer one that keeps it updated 
-    - this is not the case of a web server and its database, which can be deployed in two different nodess
+    - this is not the case of a web server and its database, which can be deployed in two different nodes
 
 {{% /col %}}
 {{% /multicol %}}

--- a/content/extra/pps-ci-introduction/_generator.md
+++ b/content/extra/pps-ci-introduction/_generator.md
@@ -32,7 +32,7 @@ enableSourceMap = true
 
 ---
 
-# Worflow organization
+# Workflow organization
 
 * Design a workflow that **fits the team**
   * Delicate balance between *chaotic organization* and *excessive bureaucracy*
@@ -700,7 +700,7 @@ The Gradle wrapper is *__the__ correct way* to use gradle, and we'll be using it
   * runs the specified main class passing the `runtimeClasspath` to the `-cp` option of `java`
   * `./gradlew` run
 
-**Note**: exectution requires a valid OMDB API Key stored as an environment variable `OMDB_API_KEY`
+**Note**: execution requires a valid OMDB API Key stored as an environment variable `OMDB_API_KEY`
 
 ---
 


### PR DESCRIPTION
### Motivation
- Improve readability and correctness of the course content by fixing spelling, grammar, and small wording issues scattered across multiple pages.
- Make code comments and prose clearer so examples and explanations are less likely to confuse readers.

### Description
- Corrected numerous typos and wording in multiple content files including `content/02-kotlin/_index.md`, `content/03-internal-dsls/_index.md`, `content/04-build-automation/_generator.md`, `content/05-version-selection/_index.md`, `content/07-ci/generator.md`, `content/08-advanced-git/_index.md`, `content/09-containerization/_index.md`, `content/12-multiplatform/_index.md`, and various `content/extra/*` pages. 
- Specific fixes include word corrections such as `backtics` → `backticks`, `Objecs` → `Objects`, `intialized` → `initialized`, `controvariance` → `contravariance`, `interoperatibility` → `interoperability`, `toke` → `token`, `happenend` → `happened`, `indipendently` → `independently`, `likey` → `likely`, `imporing` → `importing`, and similar spelling/grammar improvements. 
- Fixed minor punctuation and phrasing issues in code comments, tables, and prose (e.g., `CommonJS for JS depenencies management` → `CommonJS for JS dependencies management`) and adjusted a few small formatting items for consistency.
- These are documentation-only changes and do not alter executable application logic.

### Testing
- No automated tests were run for this PR because the changes are documentation-only and do not affect code execution or build logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69df8d873278833592cb836428f24ffc)